### PR TITLE
mock api skeleton

### DIFF
--- a/src/components/LoginForm/index.js
+++ b/src/components/LoginForm/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Formik} from 'formik';
 import { ButtonSecondary } from '../Buttons';
 import { Box, Flex } from '../../components/Layout';
+import api from '../../utils/api';
 
 const LoginFormComponent = () => (
   <div>
@@ -19,10 +20,8 @@ const LoginFormComponent = () => (
     }}
     onSubmit={(values, { setSubmitting }) => {
       setTimeout(() => {
-        fetch('/beaconsproject.uk/api/', {
-          method: 'POST',
-          body: values,
-        });
+        api.login(values);
+
         alert(JSON.stringify(values, null, 2));
         setSubmitting(false);
       }, 400);

--- a/src/components/RegisterFindForm/index.js
+++ b/src/components/RegisterFindForm/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Formik} from 'formik';
 import { ButtonSecondary } from '../Buttons';
 import { Box, Flex } from '../../components/Layout';
+import api from '../../utils/api';
 
 const RegisterFindComponent = () => (
   <div>
@@ -16,10 +17,7 @@ const RegisterFindComponent = () => (
     }}
     onSubmit={(values, { setSubmitting }) => {
       setTimeout(() => {
-        fetch('/beaconsproject.uk/api/', {
-          method: 'POST',
-          body: values,
-        });
+        api.found(values);
         alert(JSON.stringify(values, null, 2));
         setSubmitting(false);
       }, 400);

--- a/src/components/RegisterForm/index.js
+++ b/src/components/RegisterForm/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik} from 'formik';
 import { ButtonSecondary } from '../Buttons';
+import api from '../../utils/api';
 
 const RegisterFormComponent = () => (
   <div>
@@ -24,10 +25,7 @@ const RegisterFormComponent = () => (
     }}
     onSubmit={(values, { setSubmitting }) => {
       setTimeout(() => {
-        fetch('/beaconsproject.uk/api/', {
-          method: 'POST',
-          body: values,
-        });
+        api.register(values);
         alert(JSON.stringify(values, null, 2));
         setSubmitting(false);
       }, 400);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,6 @@
+import * as mock from './mock-api';
+import * as real from './real-api';
+
+const MOCK_API = true;
+
+export default (MOCK_API ? mock : real);

--- a/src/utils/mock-api.js
+++ b/src/utils/mock-api.js
@@ -1,0 +1,43 @@
+export const messages = ({ id }) => {
+  return Promise.resolve([
+    {
+      messageid: '123',
+      text: 'Hello!',
+      founddate: '2019-09-22T17:56:07Z'
+    },
+    {
+      messageid: '436',
+      text: 'Testing\nnew lines\na bit!',
+      founddate: '2019-04-10T12:20:00Z'
+    },
+    {
+      messageid: '64991',
+      text: 'One more message',
+      founddate: '2021-02-05T08:10:30Z'
+    }
+  ]);
+};
+
+export const personal = ({ id }) => {
+  return Promise.resolve({
+    name: 'Frank Drebin',
+    email: 'frank@drebin.com',
+    phone: '0123456'
+  });
+};
+
+export const register = ({ name, password, id }) => {
+  return Promise.resolve(true);
+};
+
+export const login = ({ name, password }) => {
+  return Promise.resolve('84621222-4c87-40ba-872e-1462e46adeae');
+};
+
+export const update = ({ id, name, email, phone, password }) => {
+  return Promise.resolve(true);
+};
+
+export const found = ({ id, code }) => {
+  return Promise.resolve(true);
+};

--- a/src/utils/real-api.js
+++ b/src/utils/real-api.js
@@ -1,0 +1,35 @@
+export const messages = ({ id }) => {
+  return Promise.reject('not implemented yet');
+};
+
+export const personal = ({ id }) => {
+  return Promise.reject('not implemented yet');
+};
+
+export const register = ({ name, password, id }) => {
+  fetch('/beaconsproject.uk/api/', {
+    method: 'POST',
+    body: { name, password, id }
+  });
+  return Promise.reject('not implemented yet');
+};
+
+export const login = ({ name, password }) => {
+  fetch('/beaconsproject.uk/api/', {
+    method: 'POST',
+    body: { name, password }
+  });
+  return Promise.reject('not implemented yet');
+};
+
+export const update = ({ id, name, email, phone, password }) => {
+  return Promise.reject('not implemented yet');
+};
+
+export const found = ({ id, code }) => {
+  fetch('/beaconsproject.uk/api/', {
+    method: 'POST',
+    body: { id, code }
+  });
+  return Promise.reject('not implemented yet');
+};


### PR DESCRIPTION
Skeleton mock API.

Tries to expose just the info you're interested in for your components.
When integrating with the real API you'd need to take the return codes into account (e.g. 0 meaning no error)

Turn it on/off with `MOCK_API` in `utils/api.js` - this could be turned into an environment variable, or configurable from the console at runtime. 